### PR TITLE
Mozilla fix barber shop template height

### DIFF
--- a/templates/pace-theme-barber-shop.tmpl.css
+++ b/templates/pace-theme-barber-shop.tmpl.css
@@ -28,6 +28,7 @@
   right: 100%;
   width: 100%;
   overflow: hidden;
+  height: 12px;
 }
 
 .pace .pace-activity {
@@ -36,6 +37,7 @@
   right: -32px;
   bottom: 0;
   left: 0;
+  height: 12px;
 
   -webkit-transform: translate3d(0, 0, 0);
   -moz-transform: translate3d(0, 0, 0);


### PR DESCRIPTION
Added height properties to barber shop template to prevent the pace bar
from taking the entire height of the page in Firefox.